### PR TITLE
Fix scrollTo anchor

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
@@ -5,6 +5,8 @@
 import StreamChat
 import SwiftUI
 
+/// - Note: Changes from original implementation:
+///   - scrollTo anchor on first message's scrolledId set to 0.1 instead of top
 public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
     @Injected(\.utils) private var utils
     @Injected(\.chatClient) private var chatClient
@@ -302,7 +304,8 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
                             }
                             withAnimation {
                                 if messages.first?.id == scrolledId {
-                                    scrollView.scrollTo(scrolledId, anchor: .top)
+                                    // Used to scroll to top, but doesn't inlude MessageList top(bottom) padding. So we scroll almost to top instead
+                                    scrollView.scrollTo(scrolledId, anchor: .init(x: 0.5, y: 0.1))
                                 } else {
                                     scrollView.scrollTo(scrolledId, anchor: messageListConfig.scrollingAnchor)
                                 }


### PR DESCRIPTION
We have an issue with this new code : when we open the chat, it scrolls to the last message, but with a top anchor (bottom, but the view is reversed), instead of center like before. But by aligning to the top (bottom) of the view, we don't see the list vertical padding anymore, and the "xxx is typing" is displayed on top of the message
I changed the logic so it anchors to 90% of the view instead of 100% (top). Almost the same thing, but fix our issue for the last message